### PR TITLE
Removing obsolete closing tag

### DIFF
--- a/mage-cache.xml
+++ b/mage-cache.xml
@@ -17,4 +17,3 @@
     <file_name_prefix><![CDATA[]]></file_name_prefix>
   </memcached>
 </cache>
-</config>


### PR DESCRIPTION
There is an extra </config> tag alone at the end of the xml that brek parsing.